### PR TITLE
Set read-only permissions for pull requests workflow

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -2,6 +2,9 @@ name: "🔀 Pull Request Jobs"
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request makes a small change to the GitHub Actions workflow file `.github/workflows/pull_request.yml`. The change adds a `permissions` block to specify that the workflow only requires read access to contents.

* [`.github/workflows/pull_request.yml`](diffhunk://#diff-a0fe23534b616d51ce686d2a1bcd1a78bc75074aef1a2f6ee96c9469991e1a4cR5-R7): Added a `permissions` block with `contents: read` to limit the access permissions for the pull request workflow.